### PR TITLE
feat: add release-hotfix workflow for patching release branches

### DIFF
--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -1,0 +1,32 @@
+name: Release Hotfix
+
+on:
+  push:
+    branches:
+      - release/*
+
+jobs:
+  hotfix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Bump patch version
+        run: |
+          npx standard-version --release-as patch
+
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+          git push origin HEAD --follow-tags


### PR DESCRIPTION
- Added support for automatic patch version bumps using `standard-version`.
- Triggered by pushes to `release/*` branches.
- Ensures bug fixes on release branches are properly versioned and pushed.