### PR TITLE
feat: integrate GitHub App token for secure branch protection handling

### DIFF
--- a/.github/workflows/qa-check.yml
+++ b/.github/workflows/qa-check.yml
@@ -5,9 +5,19 @@ on: [pull_request]
 jobs:
   qa-validation:
     runs-on: ubuntu-latest
+
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.VERSION_BUMPER_APPID }}
+          private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,7 +1,7 @@
 name: Release Deploy
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: # Manual trigger
   push:
     branches:
       - main
@@ -16,8 +16,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.VERSION_BUMPER_APPID }}
+          private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -30,6 +39,6 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_BOT_NPM_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -10,8 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.VERSION_BUMPER_APPID }}
+          private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release-versioning.yml
+++ b/.github/workflows/release-versioning.yml
@@ -10,8 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.VERSION_BUMPER_APPID }}
+          private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -25,14 +34,11 @@ jobs:
       - name: Generate version and changelog
         id: version
         run: |
-          npx standard-version --dry-run
-          VERSION=$(npx standard-version --first-release --dry-run | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+')
+          VERSION=$(npx standard-version --dry-run | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Generated version: $VERSION"
 
       - name: Push to release branch
-        env:
-          TOKEN: ${{ secrets.PAT }}
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
@@ -41,4 +47,4 @@ jobs:
           npx standard-version
 
           git checkout -b $RELEASE_BRANCH || git checkout $RELEASE_BRANCH
-          git push https://x-access-token:${TOKEN}@github.com/rubenszinho/gazillion-beers.git $RELEASE_BRANCH
+          git push origin HEAD --follow-tags


### PR DESCRIPTION
- Added `actions/create-github-app-token@v1` to all workflows (`qa-check`, `release-deploy`, `release-hotfix`, and `release-versioning`) for generating GitHub App tokens.
- Configured the `checkout` steps to use tokens generated by the GitHub App for fetching protected branches.
- Updated `release-deploy.yml` to replace `GITHUB_TOKEN` with `steps.app-token.outputs.token` for `semantic-release`.
- Adjusted `release-hotfix.yml` to push changes using the GitHub App token.
- Modified `release-versioning.yml` to:
  - Remove unnecessary `--first-release` flag in `standard-version` for correct version bumping.
  - Push changes using `git push origin HEAD --follow-tags`.
- Ensured secure integration with branch protection rules by utilizing GitHub App authentication across workflows.