### PR TITLE
chore: refine release and package setup

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,18 +4,16 @@
     "develop",
     {
       "name": "release/*",
-      "prerelease": true
+      "prerelease": "beta"
     }
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
     "@semantic-release/github",
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json", "CHANGELOG.md"]
+        "assets": [],
+        "message": "chore(release): ${nextRelease.version}"
       }
     ]
   ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "rubrion-frontend-template",
+  "name": "gazillion-beers",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "build": "vite build",
@@ -16,6 +16,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@semantic-release/github": "^11.0.1",
     "js-cookie": "^3.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
- Updated `.releaserc.json`:
  - Changed `prerelease` property for `release/*` branches to `beta` for proper pre-release handling.
  - Removed redundant plugins: `@semantic-release/commit-analyzer`, `@semantic-release/release-notes-generator`, and `@semantic-release/npm`.

- Updated `package.json`:
  - Renamed project from `rubrion-frontend-template` to `gazillion-beers`.
  - Set initial version to `1.0.0` to mark the first stable release.
  - Added `@semantic-release/github` as a dependency for handling GitHub releases.